### PR TITLE
Update token validation logic after migration to Entra token

### DIFF
--- a/ActionableMessageTokenValidator.js
+++ b/ActionableMessageTokenValidator.js
@@ -38,16 +38,16 @@ var oid = require('./OpenIdMetadata');
 var jwt = require('jsonwebtoken');
 
 const O365_APP_ID = "48af08dc-f6d2-435f-b2a7-069abd99c086";
-const O365_OPENID_METADATA_URL = "https://substrate.office.com/sts/common/.well-known/openid-configuration";
-const O365_TOKEN_ISSUER = "https://substrate.office.com/sts/";
+const O365_OPENID_METADATA_URL = "https://login.microsoftonline.com/<Entra-Tenant-ID>/.well-known/openid-configuration";
+const O365_TOKEN_ISSUER = "https://sts.windows.net/<Entra-Tenant-ID>/";
 
 /**
  * Result from token validation.
  */
 var ActionableMessageTokenValidationResult = (function() {
     function ActionableMessageTokenValidationResult() {
-        this.sender = "";
         this.actionPerformer = "";
+        this.scope = "";
     }
     
     return ActionableMessageTokenValidationResult;
@@ -78,7 +78,7 @@ var ActionableMessageTokenValidator = (function () {
         var decoded = jwt.decode(token, { complete: true });
         var verifyOptions = {
             issuer: O365_TOKEN_ISSUER,
-            audience: targetUrl
+            audience: decoded.payload.aud
         };
         
         var openIdMetadata = new oid.OpenIdMetadata(O365_OPENID_METADATA_URL)
@@ -95,8 +95,8 @@ var ActionableMessageTokenValidator = (function () {
                         Error.captureStackTrace(error);
                         cb(error);
                     } else {
-                        result.sender = decoded.payload.sender;
-                        result.actionPerformer = decoded.payload.sub;
+                        result.scope = decoded.payload.scp;
+                        result.actionPerformer = decoded.payload.upn;
                     }
                 } catch (err) {
                     cb(err);


### PR DESCRIPTION
External access tokens for actionable messages will be retired by March 31, 2026, requiring organizations to switch to Microsoft Entra authentication (See https://mc.merill.net/message/MC1189663).

After migration to Entra tokens, the validation logic used in actionable message handlers has to be adapted.

Note that the result fields change:
1. "sender" is no longer part of the token and therefore removed.
2. "actionPerformer" is filled with "upn" claim (User Principal Name) instead of "sub" claim.
3. A new field "scope" is introduced that is filled from "scp" claim and can be used for additional checks.

Please also see https://learn.microsoft.com/en-us/outlook/actionable-messages/enable-entra-token-for-actionable-messages#validate-the-aad-token